### PR TITLE
feat: Implement mobile hamburger menu and layout adjustments

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -54,6 +54,17 @@ img {
   transition: color 0.3;
 }
 
+/* Hamburger Menu Button */
+.hamburger-menu {
+  display: none; /* Hidden by default */
+  background-color: transparent;
+  border: 1px solid #000;
+  padding: 8px 12px;
+  font-size: 1.5rem;
+  cursor: pointer;
+  /* align-self: flex-end; */ /* No longer needed, parent .header-top-row handles alignment */
+}
+
 .body {
   display: flexbox;
   justify-content: center;
@@ -161,16 +172,41 @@ img {
 @media (max-width: 768px) {
   .header {
     flex-direction: column;
-    align-items: flex-start;
+    align-items: flex-start; /* Or stretch, if children should take full width by default */
     padding: 12px;
   }
 
+  .header-top-row {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+  }
+
+  .hamburger-menu {
+    display: block; /* Show on mobile */
+    /* No margin-bottom needed here now, spacing handled by .nav's margin-top */
+  }
+
   .nav {
+    display: none; /* Hidden by default on mobile */
     flex-direction: column;
     gap: 10px;
     font-size: 1em;
     width: 100%;
     margin-top: 10px;
+  }
+
+  .nav.nav-mobile-open {
+    display: flex; /* Show when menu is open */
+    align-items: center; /* Center the link items (<a> tags) */
+  }
+
+  .nav.nav-mobile-open a {
+    text-align: center; /* Center text within each link */
+    width: fit-content; /* Make link width just enough for its content */
+    padding: 5px 0; /* Add some vertical padding for better touch and visual */
   }
 
   .body h1 {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,16 +1,29 @@
 import { Link } from 'react-router-dom';
+import { useState } from 'react';
 import GeneralsMascot from '../assets/Logos/GeneralsMascot.png'
 import Generals from '../assets/Logos/GeneralsBlack.png'
 
 const Header = () => {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
 
+  const toggleMenu = () => {
+    setIsMenuOpen(!isMenuOpen);
+    console.log('onClick, new isMenuOpen:', !isMenuOpen); // Log new state
+  };
+
+  console.log('Header render, isMenuOpen:', isMenuOpen); // Log on render
   return (
     <header className='header'>
-      <Link to='/' className='logo'>
-        <img className='logo-img' src={GeneralsMascot} />
-        <img className='logo-text' src={Generals} />
-      </Link>
-      <div className='nav'>
+      <div className="header-top-row">
+        <Link to='/' className='logo'>
+          <img className='logo-img' src={GeneralsMascot} />
+          <img className='logo-text' src={Generals} />
+        </Link>
+        <button className='hamburger-menu' onClick={toggleMenu}>
+          ☰
+        </button>
+      </div>
+      <div className={`nav ${isMenuOpen ? 'nav-mobile-open' : ''}`}>
         <Link to='/about'>About</Link>
         <Link to='/sponsors'>Sponsors</Link>
         <Link to='/forms'>Forms</Link>


### PR DESCRIPTION
- Added a hamburger menu for mobile viewports (<= 768px).
- Includes JavaScript for toggling menu visibility and CSS for styling.
- Adjusted mobile header layout to position the logo on the left and the hamburger icon on the right, on the same line.
- Centered navigation links within the opened mobile menu.
- Ensured desktop navigation remains unchanged.

Output: