### PR TITLE
Fix cPanel deployment by building on the server

### DIFF
--- a/.cpanel.yml
+++ b/.cpanel.yml
@@ -1,9 +1,7 @@
 ---
 deployment:
   tasks:
-  # Path to your public_html folder
     - export DEPLOYPATH=/home/utahkiar/public_html/
-    # Copy the built assets folder
-    - /bin/cp -R dist/assets $DEPLOYPATH
-    # Copy the main index.html
-    - /bin/cp dist/index.html $DEPLOYPATH
+    - npm install
+    - npm run build
+    - /bin/cp -R dist/* $DEPLOYPATH

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,16 +21,7 @@ jobs:
         with:
           node-version: '22'
 
-      # 3️⃣ Install dependencies
-      - name: Install dependencies
-        run: npm ci
-
-      # 4️⃣ Build Vite app
-      - name: Build project
-        run: npm run build
-
-
-      # 5️⃣ Deploy to cPanel
+      # 3️⃣ Deploy to cPanel
       - name: Deploy to cPanel
         id: deploy
         uses: pinkasey/cpanel-deploy-action@v1.2.1


### PR DESCRIPTION
The cPanel deployment was failing because the build was being performed in the GitHub Actions runner, but the deployment action (`pinkasey/cpanel-deploy-action`) works by triggering a `git pull` on the cPanel server and then running the deployment tasks from `.cpanel.yml`.

The `.cpanel.yml` file was missing the necessary build steps. This change moves the build process to the cPanel server by adding `npm install` and `npm run build` commands to the `.cpanel.yml` file.

The redundant build steps have been removed from the GitHub Actions workflow.