### PR TITLE
Add debugging commands to cPanel deployment

### DIFF
--- a/.cpanel.yml
+++ b/.cpanel.yml
@@ -1,7 +1,10 @@
 ---
 deployment:
   tasks:
+    - set -x
     - export DEPLOYPATH=/home/utahkiar/public_html/
-    - npm install
-    - npm run build
-    - /bin/cp -R dist/* $DEPLOYPATH
+    - /bin/cp -R * $DEPLOYPATH
+    - /bin/cp -R .[^.]* $DEPLOYPATH
+    - cd /home/utahkiar/public_html/
+    - /usr/bin/npm install
+    - /usr/bin/npm run build


### PR DESCRIPTION
The cPanel deployment is failing with an unhelpful error message. This change adds debugging commands to the `.cpanel.yml` file to get more information about the execution environment on the cPanel server.

The following commands have been added:
- `set -x`: To trace the execution of the script.
- Copy all files to the public_html directory before running npm install.
- Changed to the public_html directory before running npm install.
- Use absolute paths for npm.