### PR TITLE
Simplify .cpanel.yml for debugging

### DIFF
--- a/.cpanel.yml
+++ b/.cpanel.yml
@@ -1,10 +1,4 @@
 ---
 deployment:
   tasks:
-    - set -x
-    - export DEPLOYPATH=/home/utahkiar/public_html/
-    - /bin/cp -R * $DEPLOYPATH
-    - /bin/cp -R .[^.]* $DEPLOYPATH
-    - cd /home/utahkiar/public_html/
-    - /usr/bin/npm install
-    - /usr/bin/npm run build
+    - ls -la /home/utahkiar/repositories/generals-baseball


### PR DESCRIPTION
The cPanel deployment is failing without a clear error message. This change simplifies the `.cpanel.yml` file to a single `ls -la` command to test if any command can be executed and its output returned. This is a debugging step to establish a baseline for further investigation.