### PR TITLE
Add enhanced debugging to .cpanel.yml

### DIFF
--- a/.cpanel.yml
+++ b/.cpanel.yml
@@ -1,6 +1,10 @@
 ---
 deployment:
   tasks:
+    - set -exv
     - export DEPLOYPATH=/home/utahkiar/public_html/
-    - /bin/cp -R * $DEPLOYPATH
-    - /bin/cp -R .[^.]* $DEPLOYPATH
+    - echo "--- Copying files ---"
+    - /bin/cp -vR * $DEPLOYPATH
+    - echo "--- Copying hidden files ---"
+    - /bin/cp -vR .[^.]* $DEPLOYPATH || echo "No hidden files to copy"
+    - echo "--- Done ---"


### PR DESCRIPTION
The deployment is failing without a clear error message. This change adds more verbose debugging to the `.cpanel.yml` file, including `set -exv`, echo statements, and verbose flags for `cp`. This is to get more information from the cPanel server during deployment.