### PR TITLE
Debug npm installation on cPanel

### DIFF
--- a/.cpanel.yml
+++ b/.cpanel.yml
@@ -8,8 +8,15 @@ deployment:
     - echo "--- Copying hidden files ---"
     - /bin/cp -vR .[^.]* $DEPLOYPATH || echo "No hidden files to copy"
     - echo "--- Done copying files ---"
+    - echo "--- Checking for npm ---"
+    - which npm
+    - command -v npm
+    - npm -v
     - echo "--- Changing directory to public_html ---"
     - cd $DEPLOYPATH
-    - echo "--- Installing npm dependencies ---"
+    - pwd
+    - echo "--- Listing files in public_html ---"
+    - ls -la
+    - echo "--- Attempting npm install ---"
     - /usr/bin/npm install
-    - echo "--- Done installing ---"
+    - echo "--- Done ---"


### PR DESCRIPTION
The deployment is failing at the `npm install` step. This change adds commands to the `.cpanel.yml` file to check for the existence, location, and version of npm on the cPanel server. This is to gather more information to debug the installation failure.