### PR TITLE
Add deployment logging to .cpanel.yml

### DIFF
--- a/.cpanel.yml
+++ b/.cpanel.yml
@@ -1,22 +1,21 @@
 ---
 deployment:
   tasks:
-    - set -exv
     - export DEPLOYPATH=/home/utahkiar/public_html/
-    - echo "--- Copying files ---"
-    - /bin/cp -vR * $DEPLOYPATH
-    - echo "--- Copying hidden files ---"
-    - /bin/cp -vR .[^.]* $DEPLOYPATH || echo "No hidden files to copy"
-    - echo "--- Done copying files ---"
-    - echo "--- Checking for npm ---"
-    - which npm
-    - command -v npm
-    - npm -v
-    - echo "--- Changing directory to public_html ---"
+    - echo "--- Starting deployment ---" > $DEPLOYPATH/deploy-log.txt
+    - date >> $DEPLOYPATH/deploy-log.txt
+    - echo "--- Checking environment ---" >> $DEPLOYPATH/deploy-log.txt
+    - whoami >> $DEPLOYPATH/deploy-log.txt 2>&1
+    - pwd >> $DEPLOYPATH/deploy-log.txt 2>&1
+    - echo "--- Checking npm ---" >> $DEPLOYPATH/deploy-log.txt
+    - which npm >> $DEPLOYPATH/deploy-log.txt 2>&1
+    - npm -v >> $DEPLOYPATH/deploy-log.txt 2>&1
+    - echo "--- Copying files ---" >> $DEPLOYPATH/deploy-log.txt
+    - /bin/cp -vR * $DEPLOYPATH >> $DEPLOYPATH/deploy-log.txt 2>&1
+    - /bin/cp -vR .[^.]* $DEPLOYPATH >> $DEPLOYPATH/deploy-log.txt 2>&1 || echo "No hidden files" >> $DEPLOYPATH/deploy-log.txt
+    - echo "--- Changing to public_html ---" >> $DEPLOYPATH/deploy-log.txt
     - cd $DEPLOYPATH
-    - pwd
-    - echo "--- Listing files in public_html ---"
-    - ls -la
-    - echo "--- Attempting npm install ---"
-    - /usr/bin/npm install
-    - echo "--- Done ---"
+    - echo "--- Running npm install ---" >> $DEPLOYPATH/deploy-log.txt
+    - /usr/bin/npm install >> $DEPLOYPATH/deploy-log.txt 2>&1
+    - echo "--- npm install finished ---" >> $DEPLOYPATH/deploy-log.txt
+    - date >> $DEPLOYPATH/deploy-log.txt


### PR DESCRIPTION
The deployment is failing silently on the cPanel server. This change modifies the `.cpanel.yml` script to redirect all of its output and errors to a log file named `deploy-log.txt` in the `public_html` directory. This is an attempt to capture the error message from the failing `npm install` command.