### PR TITLE
feat: Implement Git-based deployment for cPanel

### DIFF
--- a/.cpanel.yml
+++ b/.cpanel.yml
@@ -2,5 +2,5 @@
 deployment:
   tasks:
     - export DEPLOYPATH=/home/utahkiar/public_html/
-    - /dist/cp -R assets $DEPLOYPATH
-    - /dist/cp index.html $DEPLOYPATH
+    - /bin/rm -rf $DEPLOYPATH/*
+    - /bin/cp -R ./* $DEPLOYPATH

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Deploy React Vite site to cPanel
+name: Build and Deploy to build-artifacts branch
 
 on:
   push:
@@ -7,39 +7,27 @@ on:
   workflow_dispatch:
 
 jobs:
-  deploy:
+  build-and-deploy:
     runs-on: ubuntu-latest
-
     steps:
-      # 1️⃣ Checkout repo
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      # 2️⃣ Setup Node.js
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
 
-      # 3️⃣ Install dependencies
       - name: Install dependencies
         run: npm ci
 
-      # 4️⃣ Build Vite app
       - name: Build project
         run: npm run build
 
-      # 5️⃣ Deploy to cPanel
-      - name: Deploy to cPanel
-        id: deploy
-        uses: pinkasey/cpanel-deploy-action@v1.2.1
+      - name: Deploy to build-artifacts branch
+        uses: peaceiris/actions-gh-pages@v4
         with:
-          hostname: 'https://server355.web-hosting.com'
-          cpanel_username: 'utahkiar'
-          cpanel_token: ${{ secrets.CPANEL_TOKEN }}
-          repository_root: '/home/utahkiar/repositories/generals-baseball'
-          updateRepository: true
-          branch: 'main'
-
-      - name: echo deploy-duration  
-        run: echo "Deployment took ${{ steps.deploy.outputs.duration }} milliseconds"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          publish_branch: build-artifacts
+          force_orphan: true


### PR DESCRIPTION
This commit refactors the deployment process to use a Git-based strategy, working around server restrictions that block FTP connections.

The new workflow is as follows:
1. On a push to the `main` branch, the GitHub Action builds the project.
2. The contents of the build output (`dist` directory) are pushed to a dedicated `build-artifacts` branch.
3. A corrected `.cpanel.yml` script is included, which instructs cPanel to deploy the files from the `build-artifacts` branch to the `public_html` directory.

This approach automates the deployment process in a way that is compatible with the hosting environment, separating source code from build artifacts. The original, non-functional cPanel action has been removed.