### PR TITLE
fix: Add write permissions to deployment workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
This commit addresses a permission error in the GitHub Actions workflow. The `peaceiris/actions-gh-pages` action was failing with a 403 Forbidden error because the default `GITHUB_TOKEN` did not have permissions to write to the repository.

This is resolved by explicitly granting `contents: write` permission to the `build-and-deploy` job. This allows the action to successfully create and push the `build-artifacts` branch.