### PR TITLE
chore: Set main as deployment branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,9 @@
-name: Build and Deploy to build-artifacts branch
+name: Build and Deploy to main branch
 
 on:
   push:
     branches:
-      - main
+      - develop
   workflow_dispatch:
 
 jobs:
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: 'develop'
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -26,10 +28,10 @@ jobs:
       - name: Build project
         run: npm run build
 
-      - name: Deploy to build-artifacts branch
+      - name: Deploy to main branch
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
-          publish_branch: build-artifacts
+          publish_branch: main
           force_orphan: true


### PR DESCRIPTION
This commit finalizes the deployment strategy to work around a cPanel issue where it defaults to tracking the main branch.

The GitHub Actions workflow is updated to:
- Trigger on pushes to a new `develop` branch.
- Check out the `develop` branch for building.
- Push the build artifacts to the `main` branch.

This aligns with the cPanel behavior, ensuring that the deployed branch contains the correct production-ready files.