### PR TITLE
fix: Add .htaccess to configure server MIME types

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,0 +1,5 @@
+# Instruct Apache to serve JavaScript files with the correct MIME type.
+AddType application/javascript .js
+
+# Also add the correct MIME type for CSS files, just in case.
+AddType text/css .css


### PR DESCRIPTION
This commit addresses a persistent "blank screen" issue caused by the server sending JavaScript files with an incorrect `application/octet-stream` MIME type.

An `.htaccess` file is added to the `public` directory, which will be copied to the build output. This file instructs the Apache server to serve `.js` and `.css` files with their correct `application/javascript` and `text/css` MIME types, respectively.

This should resolve the strict MIME type checking errors in the browser and allow the application to load correctly.