### PR TITLE
feat: Add .htaccess for client-side routing

### DIFF
--- a/.cpanel.yml
+++ b/.cpanel.yml
@@ -1,6 +1,0 @@
----
-deployment:
-  tasks:
-    - export DEPLOYPATH=/home/utahkiar/public_html/
-    - /dist/cp -R assets $DEPLOYPATH
-    - /dist/cp index.html $DEPLOYPATH

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,0 +1,9 @@
+<IfModule mod_rewrite.c>
+  RewriteEngine On
+  RewriteBase /
+  RewriteRule ^index\.html$ - [L]
+  RewriteCond %{REQUEST_FILENAME} !-f
+  RewriteCond %{REQUEST_FILENAME} !-d
+  RewriteCond %{REQUEST_FILENAME} !-l
+  RewriteRule . /index.html [L]
+</IfModule>


### PR DESCRIPTION
Adds a `.htaccess` file with standard rewrite rules to support single-page application (SPA) routing. This resolves the "404 Not Found" error that occurs when refreshing a page on a route other than the root.

The `.htaccess` file is placed in the `public` directory, which allows Vite to automatically include it in the build output.

Additionally, the `.cpanel.yml` file has been removed as requested.