### PR TITLE
fix: Use copyfiles with -f flag for robust .htaccess copying

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build && copyfiles -u 1 public/.htaccess dist",
+    "build": "tsc -b && vite build && copyfiles -f public/.htaccess dist",
     "lint": "eslint .",
     "preview": "vite preview"
   },


### PR DESCRIPTION
This commit resolves the issue of the `.htaccess` file not being included in the production build output.

The `build` script in `package.json` is updated to use `copyfiles -f`. The `-f` (flat) flag provides a more reliable method for copying the file into the root of the `dist` directory than the previously attempted `-u` flag, which was not working consistently in the user's environment.

This ensures that the `.htaccess` file, which is critical for single-page application routing on Apache servers, is always present in the final build, thus fixing the "404 Not Found" error on page refresh.

This commit also includes the creation of the `public/.htaccess` file and the addition of the `copyfiles` dev dependency. The `.cpanel.yml` file remains deleted as per the user's request.